### PR TITLE
Detect out-of-tree operations and warn the user

### DIFF
--- a/squilt
+++ b/squilt
@@ -53,6 +53,18 @@ pkgroot = Path(os.getcwd())
 if (pkgroot / "patches").is_symlink():
     pkgroot = pkgroot.parent
 
+# Out-of-tree operations require an extra mount. We could just mount the
+# sourcedir automatically, but then subsequent operations like `quilt push`
+# would still fail. Let's inform the user instead.
+if "--sourcedir" in sys.argv:
+    sourcedir = Path(sys.argv[sys.argv.index("--sourcedir") + 1]).resolve()
+    is_below_pkgroot = pkgroot.resolve() in sourcedir.parents \
+        or pkgroot == sourcedir
+    if not (is_below_pkgroot or "SQUILT_EXTRA_MOUNTS" in os.environ):
+        eprint("Out-of-tree operations require an extra mount. For example:\n"
+               f"""export SQUILT_EXTRA_MOUNTS='MountSpec(src="{sourcedir}")'""",
+               exit=1)
+
 mounts = [
     MountSpec(src="/bin"),
     MountSpec(src="/lib"),


### PR DESCRIPTION
quilt has an option `--sourcedir` that's currently broken with squilt.

We could just mount the source directory automatically to make the current operation work, but then subsequent operations like `squilt push` would still fail because patches are symlinked to the sourcedir. Let's inform the user instead.

Example:
```
$ squilt setup -v --sourcedir "/absolute/path/package/" "/absolute/path/package/package.spec"
Out-of-tree operations require an extra mount. For example:
export SQUILT_EXTRA_MOUNTS='MountSpec(src="/absolute/path/package")'
```